### PR TITLE
feat: 优化搜索组件中RangePicker和Select组件的取值方式

### DIFF
--- a/packages/legions-pro-design/src/components/LegionsProConditions/conditions.tsx
+++ b/packages/legions-pro-design/src/components/LegionsProConditions/conditions.tsx
@@ -286,6 +286,25 @@ export default class LegionsProConditions<Query = {}> extends React.Component<IP
             callback(value);
         });
     }
+    mapPrams(item: Exclude<IProConditions['componentModel'], ConditionSearchModel>, data: {}, prams: {}) {
+        if (item instanceof ConditionRangePickerModel && item.jsonProperty.includes(',')) {
+            const startTime = data[0]
+            const endTime = data[1]
+            const format = item.conditionsProps.transformFormat
+            const paramslist = item.jsonProperty.split(',')
+            prams[paramslist[0].trim()] = format && startTime && moment(startTime).format(format) || startTime
+            prams[paramslist[1].trim()] = format && endTime && moment(endTime).format(format) || endTime
+        } else if (item instanceof ConditionSelectModel && item.jsonProperty.includes(',') && item.conditionsProps.labelInValue) {
+            const key = data['key']
+            const label = data['label']
+            const paramslist = item.jsonProperty.split(',')
+            prams[paramslist[0].trim()] = key
+            prams[paramslist[1].trim()] = label
+        } else {
+            prams[item.jsonProperty] = data
+        }
+        return prams
+    }
     initVModel(query=this.props.query) {
         let data = {}
         let prams = {}
@@ -327,7 +346,7 @@ export default class LegionsProConditions<Query = {}> extends React.Component<IP
                         data[name] = defaultValue || value
                     }
                 }
-                prams[item.jsonProperty] = data[name];
+                prams = this.mapPrams(item, data[name], prams)
             }
         })
         this.queryPrams = prams;
@@ -343,7 +362,7 @@ export default class LegionsProConditions<Query = {}> extends React.Component<IP
         let prams = this.queryPrams
         computedQuery.map((item) => {
             if (!(item instanceof ConditionSearchModel)) {
-                prams[item.jsonProperty] = this.vmModel[item.containerProps.name]
+                prams = this.mapPrams(item, this.vmModel[item.containerProps.name], prams)
             }
         })
         this.queryPrams = prams;

--- a/packages/legions-pro-design/src/components/LegionsProConditions/interface/index.ts
+++ b/packages/legions-pro-design/src/components/LegionsProConditions/interface/index.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: duanguang
  * @Date: 2021-01-08 12:00:22
- * @LastEditTime: 2021-03-09 22:36:40
- * @LastEditors: duanguang
+ * @LastEditTime: 2021-03-25 10:12:31
+ * @LastEditors: zhaoliang
  * @Description: 
  * @FilePath: /legions-design-element/packages/legions-pro-design/src/components/LegionsProConditions/interface/index.ts
  * @「扫去窗上的尘埃，才可以看到窗外的美景。」
@@ -131,6 +131,8 @@ export interface IQueryDateProps extends IQueryProps ,Weaken<DatePickerProps,'on
 }
 export interface IQueryRangePickerProps extends IQueryProps, Weaken<RangePickerProps,'onChange'|'placeholder'>{
     placeholder?: [string,string]
+    /** 取值时对日期进行格式化 */
+    transformFormat?: string
     /** 只读 */
     readonly onChange?: (originValue: {
         date: [moment.Moment,moment.Moment], dateString: [string, string]

--- a/packages/legions-pro-design/src/components/LegionsProConditions/interface/index.ts
+++ b/packages/legions-pro-design/src/components/LegionsProConditions/interface/index.ts
@@ -1,7 +1,7 @@
 /*
  * @Author: duanguang
  * @Date: 2021-01-08 12:00:22
- * @LastEditTime: 2021-03-25 10:12:31
+ * @LastEditTime: 2021-03-25 14:24:26
  * @LastEditors: zhaoliang
  * @Description: 
  * @FilePath: /legions-design-element/packages/legions-pro-design/src/components/LegionsProConditions/interface/index.ts
@@ -131,7 +131,7 @@ export interface IQueryDateProps extends IQueryProps ,Weaken<DatePickerProps,'on
 }
 export interface IQueryRangePickerProps extends IQueryProps, Weaken<RangePickerProps,'onChange'|'placeholder'>{
     placeholder?: [string,string]
-    /** 取值时对日期进行格式化 */
+    /** 取值时对日期进行格式化 参数详情见moment.js官方文档: http://momentjs.cn/docs/#/displaying/format/ */
     transformFormat?: string
     /** 只读 */
     readonly onChange?: (originValue: {

--- a/packages/legions-pro-design/src/examples/containers/proQuery/index.tsx
+++ b/packages/legions-pro-design/src/examples/containers/proQuery/index.tsx
@@ -98,7 +98,7 @@ export default class QueryDemo extends React.Component<{},Istate>{
                     { key: '333',value: '昊链科技3' },
                     { key: '444',value: '昊链科技4' }]
             },
-            jsonProperty:'orderNo2'
+            jsonProperty:'companyCode,companyName'
         })
         formUtils.renderDateConfig({
             containerProps: {
@@ -142,8 +142,9 @@ export default class QueryDemo extends React.Component<{},Istate>{
                 defaultValue:[moment('2015-01-01', 'YYYY-MM-DD'),moment('2016-01-01', 'YYYY-MM-DD')],
                 format: 'YYYY-MM-DD',
                 /*showTime:true, */
+                transformFormat: 'x',
             },
-            jsonProperty:'orderNo4'
+            jsonProperty: 'createTimeStart,createTimeEnd',
         })
         formUtils.renderCheckBoxConfig({
             containerProps: {


### PR DESCRIPTION
### feat: 优化搜索组件中RangePicker和Select组件的取值方式

|组件|修改内容|说明|
|:-|:-:|:-:|
|RangePicker|conditionsProps增加参数 `transformFormat?: string`, `jsonProperty`支持传入`","`隔开的字符串|将RangePicker组件的返回值`[开始日期字符串, 结束日期字符串]`转换成`jsonProperty`中使用`","`隔开的两个参数`{ jsonProperty.split(',')[0]: 开始日期字符串, jsonProperty.split(',')[1]: 结束日期字符串 }`并添加到条件对象, 如果`transformFormat`有值,则根据`transformFormat`对日期字符串进行格式化|
|Select|conditionsProps参数`jsonProperty`支持传入`","`隔开的字符串|如果组件开启`labelInValue`并传入使用`","`隔开的字符串`jsonProperty`, 则将Select组件的返回值`value: { key: string; label: string }`转换成`{ jsonProperty.split(',')[0]: value.key, jsonProperty.split(',')[1]: value.label }`并添加到条件对象|